### PR TITLE
Callback mechanism for FIPS test failures

### DIFF
--- a/crypto/crypto.c
+++ b/crypto/crypto.c
@@ -154,3 +154,20 @@ int OPENSSL_init_crypto(uint64_t opts, const OPENSSL_INIT_SETTINGS *settings) {
 }
 
 void OPENSSL_cleanup(void) {}
+
+static void default_FIPS_test_failure_cb(void* arg, int arg_type) {
+    for (;;) {
+        abort();
+        exit(1);
+    }
+}
+
+static FIPS_test_failure_cb_t fips_test_failure_cb = &default_FIPS_test_failure_cb;
+
+void set_FIPS_test_failure_cb(FIPS_test_failure_cb_t cb) {
+    fips_test_failure_cb = cb;
+}
+
+FIPS_test_failure_cb_t get_FIPS_test_failure_cb(void) {
+    return fips_test_failure_cb;
+}

--- a/crypto/fipsmodule/bcm.c
+++ b/crypto/fipsmodule/bcm.c
@@ -175,7 +175,7 @@ static void assert_within(const void *start, const void *symbol,
       stderr,
       "FIPS module doesn't span expected symbol. Expected %p <= %p < %p\n",
       start, symbol, end);
-  BORINGSSL_FIPS_abort();
+  get_FIPS_test_failure_cb()(0, 0);
 }
 
 static void assert_not_within(const void *start, const void *symbol,
@@ -192,7 +192,7 @@ static void assert_not_within(const void *start, const void *symbol,
       stderr,
       "FIPS module spans unexpected symbol, expected %p < %p || %p > %p\n",
       symbol, start, symbol, end);
-  BORINGSSL_FIPS_abort();
+  get_FIPS_test_failure_cb()(0, 0);
 }
 
 #if defined(OPENSSL_ANDROID) && defined(OPENSSL_AARCH64)
@@ -250,7 +250,7 @@ static void BORINGSSL_bcm_power_on_self_test(void) {
   return;
 
 err:
-  BORINGSSL_FIPS_abort();
+  get_FIPS_test_failure_cb()(0, 0);
 }
 
 #if !defined(OPENSSL_ASAN)
@@ -349,13 +349,6 @@ int BORINGSSL_integrity_test(void) {
   return 1;
 }
 #endif  // OPENSSL_ASAN
-
-void BORINGSSL_FIPS_abort(void) {
-  for (;;) {
-    abort();
-    exit(1);
-  }
-}
 
 #endif  // BORINGSSL_FIPS
 

--- a/crypto/fipsmodule/ec/ec_key.c
+++ b/crypto/fipsmodule/ec/ec_key.c
@@ -540,10 +540,9 @@ int EC_KEY_generate_key_fips(EC_KEY *eckey) {
   eckey->priv_key = NULL;
 
 #if defined(AWSLC_FIPS)
-  BORINGSSL_FIPS_abort();
-#else
-  return 0;
+  get_FIPS_test_failure_cb()(0, 0);
 #endif
+  return 0;
 }
 
 int EC_KEY_get_ex_new_index(long argl, void *argp, CRYPTO_EX_unused *unused,

--- a/crypto/fipsmodule/rand/rand.c
+++ b/crypto/fipsmodule/rand/rand.c
@@ -259,7 +259,7 @@ static void rand_get_seed(struct rand_thread_state *state,
   // rate of failure is small enough not to be a problem in practice.
   if (CRYPTO_memcmp(state->last_block, entropy, CRNGT_BLOCK_SIZE) == 0) {
     fprintf(stderr, "CRNGT failed.\n");
-    BORINGSSL_FIPS_abort();
+    get_FIPS_test_failure_cb()(0, 0);
   }
 
   OPENSSL_STATIC_ASSERT(sizeof(entropy) % CRNGT_BLOCK_SIZE == 0, _)
@@ -268,7 +268,7 @@ static void rand_get_seed(struct rand_thread_state *state,
     if (CRYPTO_memcmp(entropy + i - CRNGT_BLOCK_SIZE, entropy + i,
                       CRNGT_BLOCK_SIZE) == 0) {
       fprintf(stderr, "CRNGT failed.\n");
-      BORINGSSL_FIPS_abort();
+      get_FIPS_test_failure_cb()(0, 0);
     }
   }
   OPENSSL_memcpy(state->last_block,

--- a/crypto/fipsmodule/rsa/rsa_impl.c
+++ b/crypto/fipsmodule/rsa/rsa_impl.c
@@ -1426,7 +1426,7 @@ out:
   RSA_free(tmp);
 #if defined(AWSLC_FIPS)
   if (ret == 0) {
-    BORINGSSL_FIPS_abort();
+    get_FIPS_test_failure_cb()(0, 0);
   }
 #endif
   return ret;

--- a/crypto/fipsmodule/self_check/fips.c
+++ b/crypto/fipsmodule/self_check/fips.c
@@ -17,7 +17,6 @@
 #include "../../internal.h"
 #include "../delocate.h"
 
-
 int FIPS_mode(void) {
 #if defined(BORINGSSL_FIPS) && !defined(OPENSSL_ASAN)
   return 1;

--- a/crypto/fipsmodule/self_check/self_check.c
+++ b/crypto/fipsmodule/self_check/self_check.c
@@ -801,7 +801,7 @@ err:
 
 static void run_self_test_rsa(void) {
   if (!boringssl_self_test_rsa()) {
-    BORINGSSL_FIPS_abort();
+    get_FIPS_test_failure_cb()(0, 0);
   }
 }
 
@@ -813,7 +813,7 @@ void boringssl_ensure_rsa_self_test(void) {
 
 static void run_self_test_ecc(void) {
   if (!boringssl_self_test_ecc()) {
-    BORINGSSL_FIPS_abort();
+    get_FIPS_test_failure_cb()(0, 0);
   }
 }
 
@@ -825,7 +825,7 @@ void boringssl_ensure_ecc_self_test(void) {
 
 static void run_self_test_ffdh(void) {
   if (!boringssl_self_test_ffdh()) {
-    BORINGSSL_FIPS_abort();
+    get_FIPS_test_failure_cb()(0, 0);
   }
 }
 

--- a/crypto/internal.h
+++ b/crypto/internal.h
@@ -946,15 +946,6 @@ static inline uint64_t CRYPTO_rotr_u64(uint64_t value, int shift) {
 
 #if defined(BORINGSSL_FIPS)
 
-// BORINGSSL_FIPS_abort is called when a FIPS power-on or continuous test
-// fails. It prevents any further cryptographic operations by the current
-// process.
-#if defined(_MSC_VER)
-__declspec(noreturn) void BORINGSSL_FIPS_abort(void);
-#else
-void BORINGSSL_FIPS_abort(void) __attribute__((noreturn));
-#endif
-
 // boringssl_self_test_startup runs all startup self tests and returns one on
 // success or zero on error. Startup self tests do not include lazy tests.
 // Call |BORINGSSL_self_test| to run every self test.

--- a/include/openssl/crypto.h
+++ b/include/openssl/crypto.h
@@ -86,6 +86,20 @@ OPENSSL_EXPORT int CRYPTO_needs_hwcap2_workaround(void);
 
 // FIPS monitoring
 
+
+// Callback method that is invoked in case a FIPS related test fails.
+// The method takes two arguments as input: a void pointer to its input, and an
+// int indicating the type of the input. The input can be later processed by the
+// callback.
+typedef void (*FIPS_test_failure_cb_t)(void*, int);
+
+// Registers a callback method that is invoked in case a FIPS related test fails
+OPENSSL_EXPORT void set_FIPS_test_failure_cb(FIPS_test_failure_cb_t);
+
+// Return the registered method. The default method invokes abort() followed by exit(1).
+OPENSSL_EXPORT FIPS_test_failure_cb_t get_FIPS_test_failure_cb(void);
+
+
 // FIPS_mode returns zero unless BoringSSL is built with BORINGSSL_FIPS, in
 // which case it returns one.
 OPENSSL_EXPORT int FIPS_mode(void);


### PR DESCRIPTION
Adding  a callback mechanism to be used when a FIPS related check fails. In this way, users of AWS-LC can control the behaviour in such failure scenarios. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and 
the ISC license.
